### PR TITLE
Logic insert signature with quote incorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.1.5] - 2025-06-23
+- Fix for inserting logical signature with incorrect quoting
+
 ## [0.1.4] - 2025-05-23
 - Fix update DOM selector to correctly access the signature element
 

--- a/lib/src/utils/javascript_utils.dart
+++ b/lib/src/utils/javascript_utils.dart
@@ -67,9 +67,9 @@ const String jsHandleSignature = '''
           const headerQuotedMessage = document.querySelector('div#editor cite');
           const quotedMessage = document.querySelector('div#editor blockquote');
       
-          if (headerQuotedMessage) {
+          if (headerQuotedMessage && headerQuotedMessage.parentNode === nodeEditor) {
             nodeEditor.insertBefore(signatureContainer, headerQuotedMessage);
-          } else if (quotedMessage) {
+          } else if (quotedMessage && quotedMessage.parentNode === nodeEditor) {
             nodeEditor.insertBefore(signatureContainer, quotedMessage);
           } else {
             nodeEditor.appendChild(signatureContainer);
@@ -88,9 +88,9 @@ const String jsHandleSignature = '''
           const headerQuotedMessage = document.querySelector('div#editor cite');
           const quotedMessage = document.querySelector('div#editor blockquote');
       
-          if (headerQuotedMessage) {
+          if (headerQuotedMessage && headerQuotedMessage.parentNode === nodeEditor) {
             nodeEditor.insertBefore(signatureContainer, headerQuotedMessage);
-          } else if (quotedMessage) {
+          } else if (quotedMessage && quotedMessage.parentNode === nodeEditor) {
             nodeEditor.insertBefore(signatureContainer, quotedMessage);
           } else {
             nodeEditor.appendChild(signatureContainer);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: enough_html_editor
 description: Slim HTML editor for Flutter with full API control and optional Flutter-based widget controls.
-version: 0.1.4
+version: 0.1.5
 homepage: https://github.com/Enough-Software/enough_html_editor
 
 environment:


### PR DESCRIPTION
## Issue

Cannot insert signature with quote

```console
message: NotFoundError: The object can not be found here.
```

## Root cause 

This is a `DOMException` that usually occurs when trying to `insertBefore()` a node before a node that is no longer in the `DOM` or is not a direct child of the parent that is calling `insertBefore` on.

The statement causing the error:  `nodeEditor.insertBefore(signatureContainer, quotedMessage);`. `quotedMessage` is not a direct child of `nodeEditor`, will throw `NotFoundError`

## Solution

Check `parentNode === nodeEditor` before call `insertBefore` to avoid this error.


